### PR TITLE
Method name convention & concurrent take

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ fn reader(maybe: &ConcurrentOption<String>) {
     for _ in 0..100 {
         std::thread::sleep(std::time::Duration::from_millis(100));
 
-        let read = maybe.as_ref(Ordering::Acquire);
+        let read = maybe.as_ref_with_order(Ordering::Acquire);
         let is_none = read.is_none();
         let is_seven = read == Some(&7.to_string());
 
@@ -104,7 +104,7 @@ std::thread::scope(|s| {
     }
 });
 
-assert_eq!(maybe.as_ref(Ordering::Relaxed), Some(&7.to_string()));
+assert_eq!(maybe.as_ref_with_order(Ordering::Relaxed), Some(&7.to_string()));
 ```
 
 ## Contributing

--- a/src/common_traits/debug.rs
+++ b/src/common_traits/debug.rs
@@ -22,7 +22,7 @@ impl<T: Debug> Debug for ConcurrentOption<T> {
     /// assert_eq!(y, "ConcurrentNone");
     ///
     /// let x = ConcurrentOption::some(3.to_string());
-    /// let y = format!("{:?}", x.as_ref(Ordering::Acquire)); // clone with desired ordering Acquire
+    /// let y = format!("{:?}", x.as_ref_with_order(Ordering::Acquire)); // clone with desired ordering Acquire
     /// assert_eq!(y, "Some(\"3\")");
     /// ```
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/src/common_traits/from.rs
+++ b/src/common_traits/from.rs
@@ -12,7 +12,7 @@ impl<T> From<T> for ConcurrentOption<T> {
     /// use std::sync::atomic::Ordering;
     ///
     /// let x: ConcurrentOption<String> = 3.to_string().into();
-    /// assert_eq!(x.as_ref(Ordering::Relaxed), Some(&3.to_string()));
+    /// assert_eq!(x.as_ref_with_order(Ordering::Relaxed), Some(&3.to_string()));
     /// ```
     fn from(value: T) -> Self {
         ConcurrentOption::some(value)
@@ -29,10 +29,10 @@ impl<T> From<Option<T>> for ConcurrentOption<T> {
     /// use std::sync::atomic::Ordering;
     ///
     /// let x: ConcurrentOption<String> = Some(3.to_string()).into();
-    /// assert_eq!(x.as_ref(Ordering::Relaxed), Some(&3.to_string()));
+    /// assert_eq!(x.as_ref_with_order(Ordering::Relaxed), Some(&3.to_string()));
     ///
     /// let x: ConcurrentOption<String> = None.into();
-    /// assert_eq!(x.as_ref(Ordering::Relaxed), None);
+    /// assert_eq!(x.as_ref_with_order(Ordering::Relaxed), None);
     /// ```
     fn from(value: Option<T>) -> Self {
         match value {
@@ -62,6 +62,6 @@ impl<T> From<ConcurrentOption<T>> for Option<T> {
     /// assert_eq!(y, None);
     /// ```
     fn from(mut value: ConcurrentOption<T>) -> Self {
-        value.take()
+        value.exclusive_take()
     }
 }

--- a/src/common_traits/iter.rs
+++ b/src/common_traits/iter.rs
@@ -8,7 +8,7 @@ impl<'a, T> IntoIterator for &'a ConcurrentOption<T> {
     type IntoIter = Iter<'a, T>;
 
     fn into_iter(self) -> Self::IntoIter {
-        self.iter(Ordering::Relaxed)
+        self.iter_with_order(Ordering::Relaxed)
     }
 }
 
@@ -17,7 +17,7 @@ impl<'a, T> IntoIterator for &'a mut ConcurrentOption<T> {
     type IntoIter = IterMut<'a, T>;
 
     fn into_iter(self) -> Self::IntoIter {
-        self.iter_mut()
+        self.exclusive_iter_mut()
     }
 }
 
@@ -27,7 +27,7 @@ impl<T> IntoIterator for ConcurrentOption<T> {
     type IntoIter = std::option::IntoIter<T>;
 
     fn into_iter(mut self) -> Self::IntoIter {
-        self.take().into_iter()
+        self.exclusive_take().into_iter()
     }
 }
 

--- a/src/common_traits/ord.rs
+++ b/src/common_traits/ord.rs
@@ -32,8 +32,8 @@ impl<T: PartialOrd> PartialOrd for ConcurrentOption<T> {
     /// ```
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         match (
-            self.as_ref(std::sync::atomic::Ordering::Relaxed),
-            other.as_ref(std::sync::atomic::Ordering::Relaxed),
+            self.as_ref_with_order(std::sync::atomic::Ordering::Relaxed),
+            other.as_ref_with_order(std::sync::atomic::Ordering::Relaxed),
         ) {
             (Some(l), Some(r)) => l.partial_cmp(r),
             (Some(_), None) => Some(Greater),
@@ -74,8 +74,8 @@ impl<T: Ord> Ord for ConcurrentOption<T> {
     /// ```
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         match (
-            self.as_ref(std::sync::atomic::Ordering::Relaxed),
-            other.as_ref(std::sync::atomic::Ordering::Relaxed),
+            self.as_ref_with_order(std::sync::atomic::Ordering::Relaxed),
+            other.as_ref_with_order(std::sync::atomic::Ordering::Relaxed),
         ) {
             (Some(l), Some(r)) => l.cmp(r),
             (Some(_), None) => Greater,

--- a/src/concurrent_option.rs
+++ b/src/concurrent_option.rs
@@ -58,7 +58,7 @@ use std::{cell::UnsafeCell, mem::MaybeUninit, sync::atomic::AtomicU8};
 ///     for _ in 0..100 {
 ///         std::thread::sleep(std::time::Duration::from_millis(100));
 ///
-///         let read = maybe.as_ref(Ordering::Acquire);
+///         let read = maybe.as_ref_with_order(Ordering::Acquire);
 ///         let is_none = read.is_none();
 ///         let is_seven = read == Some(&7.to_string());
 ///
@@ -101,7 +101,7 @@ use std::{cell::UnsafeCell, mem::MaybeUninit, sync::atomic::AtomicU8};
 ///     }
 /// });
 ///
-/// assert_eq!(maybe.as_ref(Ordering::Relaxed), Some(&7.to_string()));
+/// assert_eq!(maybe.as_ref_with_order(Ordering::Relaxed), Some(&7.to_string()));
 /// ```
 pub struct ConcurrentOption<T> {
     pub(crate) value: UnsafeCell<MaybeUninit<T>>,

--- a/src/drop.rs
+++ b/src/drop.rs
@@ -1,6 +1,6 @@
 use crate::{
     concurrent_option::ConcurrentOption,
-    states::{SOME, WRITING},
+    states::{RESERVED_FOR_READING, SOME},
 };
 use std::sync::atomic::Ordering;
 
@@ -11,7 +11,9 @@ impl<T> Drop for ConcurrentOption<T> {
                 let x = unsafe { &mut *self.value.get() };
                 unsafe { x.assume_init_drop() };
             }
-            WRITING => panic!("ConcurrentOption is dropped while its value is being written."),
+            RESERVED_FOR_READING => {
+                panic!("ConcurrentOption is dropped while its value is being written.")
+            }
             _ => {}
         }
     }

--- a/src/into_option.rs
+++ b/src/into_option.rs
@@ -38,6 +38,6 @@ impl<T> IntoOption<T> for Option<T> {
 
 impl<T> IntoOption<T> for ConcurrentOption<T> {
     fn into_option(mut self) -> Option<T> {
-        self.take()
+        self.exclusive_take()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,7 +62,7 @@
 //!     for _ in 0..100 {
 //!         std::thread::sleep(std::time::Duration::from_millis(100));
 //!
-//!         let read = maybe.as_ref(Ordering::Acquire);
+//!         let read = maybe.as_ref_with_order(Ordering::Acquire);
 //!
 //!         let is_none = read.is_none();
 //!         let is_seven = read == Some(&7.to_string());
@@ -107,7 +107,7 @@
 //!     }
 //! });
 //!
-//! assert_eq!(maybe.as_ref(Ordering::Relaxed), Some(&7.to_string()));
+//! assert_eq!(maybe.as_ref_with_order(Ordering::Relaxed), Some(&7.to_string()));
 //! ```
 //!
 //! ## Contributing

--- a/src/new.rs
+++ b/src/new.rs
@@ -15,8 +15,8 @@ impl<T> ConcurrentOption<T> {
     /// assert_eq!(x, ConcurrentOption::some(3.to_string()));
     /// assert_ne!(x, ConcurrentOption::none());
     ///
-    /// assert!(x.is_some(Ordering::SeqCst));
-    /// assert!(!x.is_none(Ordering::Acquire));
+    /// assert!(x.is_some_with_order(Ordering::SeqCst));
+    /// assert!(!x.is_none_with_order(Ordering::Acquire));
     /// ```
     pub fn some(value: T) -> Self {
         Self {
@@ -36,14 +36,14 @@ impl<T> ConcurrentOption<T> {
     /// let x = ConcurrentOption::<String>::none();
     /// assert_ne!(x, ConcurrentOption::some(3.to_string()));
     /// assert_eq!(x, ConcurrentOption::none());
-    /// assert!(!x.is_some(Ordering::SeqCst));
-    /// assert!(x.is_none(Ordering::Acquire));
+    /// assert!(!x.is_some_with_order(Ordering::SeqCst));
+    /// assert!(x.is_none_with_order(Ordering::Acquire));
     ///
     /// let x = ConcurrentOption::default();
     /// assert_ne!(x, ConcurrentOption::some(3.to_string()));
     /// assert_eq!(x, ConcurrentOption::none());
-    /// assert!(!x.is_some(Ordering::Relaxed));
-    /// assert!(x.is_none(Ordering::Relaxed));
+    /// assert!(!x.is_some_with_order(Ordering::Relaxed));
+    /// assert!(x.is_none_with_order(Ordering::Relaxed));
     /// ```
     pub fn none() -> Self {
         let value = MaybeUninit::uninit();

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -58,7 +58,7 @@ impl<T> ConcurrentOption<T> {
     /// let p = x.raw_get_mut(Ordering::Relaxed);
     /// let p = p.unwrap();
     /// let _ = unsafe { p.replace(7.to_string()) }; // only write leads to memory leak
-    /// assert_eq!(x.as_ref(Ordering::Relaxed), Some(&7.to_string()));
+    /// assert_eq!(x.as_ref_with_order(Ordering::Relaxed), Some(&7.to_string()));
     /// ```
     pub fn raw_get_mut(&self, order: Ordering) -> Option<*mut T> {
         match self.state.load(order) {

--- a/src/states.rs
+++ b/src/states.rs
@@ -1,3 +1,3 @@
 pub(crate) const NONE: u8 = 0;
-pub(crate) const WRITING: u8 = 1;
+pub(crate) const RESERVED_FOR_READING: u8 = 1;
 pub(crate) const SOME: u8 = 2;

--- a/tests/common_traits.rs
+++ b/tests/common_traits.rs
@@ -6,15 +6,15 @@ fn clone() {
     let x = ConcurrentOption::some(3.to_string());
     let y = x.clone();
 
-    assert!(y.is_some(Ordering::Relaxed));
-    assert_eq!(y.as_ref(Ordering::Relaxed), Some(&3.to_string()));
+    assert!(y.is_some_with_order(Ordering::Relaxed));
+    assert_eq!(y.as_ref_with_order(Ordering::Relaxed), Some(&3.to_string()));
     assert_eq!(x, y);
 
     let x = ConcurrentOption::<String>::none();
     let y = x.clone();
 
-    assert!(y.is_none(Ordering::Relaxed));
-    assert_eq!(y.as_ref(Ordering::Relaxed), None);
+    assert!(y.is_none_with_order(Ordering::Relaxed));
+    assert_eq!(y.as_ref_with_order(Ordering::Relaxed), None);
     assert_eq!(x, y);
 }
 
@@ -89,13 +89,13 @@ fn eq() {
 #[test]
 fn from() {
     let x: ConcurrentOption<String> = 3.to_string().into();
-    assert_eq!(x.as_ref(Ordering::Relaxed), Some(&3.to_string()));
+    assert_eq!(x.as_ref_with_order(Ordering::Relaxed), Some(&3.to_string()));
 
     let x: ConcurrentOption<String> = Some(3.to_string()).into();
-    assert_eq!(x.as_ref(Ordering::Relaxed), Some(&3.to_string()));
+    assert_eq!(x.as_ref_with_order(Ordering::Relaxed), Some(&3.to_string()));
 
     let x: ConcurrentOption<String> = None.into();
-    assert_eq!(x.as_ref(Ordering::Relaxed), None);
+    assert_eq!(x.as_ref_with_order(Ordering::Relaxed), None);
 }
 
 #[test]

--- a/tests/concurrent_basic.rs
+++ b/tests/concurrent_basic.rs
@@ -6,12 +6,12 @@ fn initialize_if_none() {
     let x = ConcurrentOption::<String>::none();
     let inserted = x.initialize_if_none(3.to_string());
     assert!(inserted);
-    assert_eq!(x.as_ref(Ordering::Relaxed), Some(&3.to_string()));
+    assert_eq!(x.as_ref_with_order(Ordering::Relaxed), Some(&3.to_string()));
 
     let x = ConcurrentOption::some(7.to_string());
     let inserted = x.initialize_if_none(3.to_string());
     assert!(!inserted);
-    assert_eq!(x.as_ref(Ordering::Relaxed), Some(&7.to_string()));
+    assert_eq!(x.as_ref_with_order(Ordering::Relaxed), Some(&7.to_string()));
 }
 
 #[test]
@@ -19,9 +19,20 @@ fn initialize_if_none() {
 fn initialize_unchecked() {
     let x = ConcurrentOption::<String>::none();
     unsafe { x.initialize_unchecked(3.to_string()) };
-    assert_eq!(x.as_ref(Ordering::Relaxed), Some(&3.to_string()));
+    assert_eq!(x.as_ref_with_order(Ordering::Relaxed), Some(&3.to_string()));
 
     let x = ConcurrentOption::some(7.to_string());
     unsafe { x.initialize_unchecked(3.to_string()) };
-    assert_eq!(x.as_ref(Ordering::Relaxed), Some(&3.to_string()));
+    assert_eq!(x.as_ref_with_order(Ordering::Relaxed), Some(&3.to_string()));
+}
+
+#[test]
+fn map_ref() {
+    let x = ConcurrentOption::<String>::none();
+    let len = x.map_ref(|x| x.len());
+    assert_eq!(len, None);
+
+    let x = ConcurrentOption::some(7.to_string());
+    let len = x.map_ref(|x| x.len());
+    assert_eq!(len, Some(1));
 }

--- a/tests/concurrent_initialize_if_none.rs
+++ b/tests/concurrent_initialize_if_none.rs
@@ -62,7 +62,7 @@ fn concurrent_initialize_if_none_multiple_writer(
 fn read(do_sleep: bool, maybe_ref: &ConcurrentOption<String>, read_order: Ordering) {
     for _ in 0..100 {
         sleep(do_sleep);
-        let read = maybe_ref.as_ref(read_order);
+        let read = maybe_ref.as_ref_with_order(read_order);
         let is_none = read.is_none();
         let is_seven = read == Some(&7.to_string());
         assert!(is_none || is_seven);

--- a/tests/concurrent_initialize_unchecked.rs
+++ b/tests/concurrent_initialize_unchecked.rs
@@ -28,7 +28,7 @@ fn concurrent_initialize_unchecked(num_readers: usize, do_sleep: bool, read_orde
 fn read(do_sleep: bool, maybe_ref: &ConcurrentOption<String>, read_order: Ordering) {
     for _ in 0..100 {
         sleep(do_sleep);
-        let read = maybe_ref.as_ref(read_order);
+        let read = maybe_ref.as_ref_with_order(read_order);
         let is_none = read.is_none();
         let is_seven = read == Some(&7.to_string());
         assert!(is_none || is_seven);

--- a/tests/iter.rs
+++ b/tests/iter.rs
@@ -2,7 +2,7 @@ use orx_concurrent_option::*;
 use std::sync::atomic::Ordering;
 
 #[test]
-fn iter_when_none() {
+fn iter_with_order_when_none() {
     fn validate<'a>(mut iter: impl ExactSizeIterator<Item = &'a String>) {
         assert_eq!(iter.len(), 0);
         assert!(iter.next().is_none());
@@ -10,8 +10,8 @@ fn iter_when_none() {
     }
 
     let x = ConcurrentOption::<String>::none();
-    validate(x.iter(Ordering::Relaxed));
-    validate(x.iter(Ordering::Relaxed).rev());
+    validate(x.iter_with_order(Ordering::Relaxed));
+    validate(x.iter_with_order(Ordering::Relaxed).rev());
     validate((&x).into_iter());
 
     fn validate_value(mut iter: impl ExactSizeIterator<Item = String>) {
@@ -21,13 +21,13 @@ fn iter_when_none() {
     }
 
     let x = ConcurrentOption::<String>::none();
-    validate_value(x.iter(Ordering::Acquire).cloned());
-    validate_value(x.iter(Ordering::SeqCst).rev().cloned());
+    validate_value(x.iter_with_order(Ordering::Acquire).cloned());
+    validate_value(x.iter_with_order(Ordering::SeqCst).rev().cloned());
     validate_value(x.into_iter());
 }
 
 #[test]
-fn iter_when_some() {
+fn exclusive_iter_when_some() {
     fn validate<'a>(mut iter: impl ExactSizeIterator<Item = &'a String>) {
         assert_eq!(iter.len(), 1);
         assert_eq!(iter.next(), Some(&3.to_string()));
@@ -37,8 +37,8 @@ fn iter_when_some() {
     }
 
     let x = ConcurrentOption::some(3.to_string());
-    validate(x.iter(Ordering::Relaxed));
-    validate(x.iter(Ordering::Relaxed).rev());
+    validate(x.iter_with_order(Ordering::Relaxed));
+    validate(x.iter_with_order(Ordering::Relaxed).rev());
     validate((&x).into_iter());
 
     fn validate_value(mut iter: impl ExactSizeIterator<Item = String>) {
@@ -50,7 +50,7 @@ fn iter_when_some() {
     }
 
     let x = ConcurrentOption::some(3.to_string());
-    validate_value(x.iter(Ordering::Relaxed).cloned());
-    validate_value(x.iter(Ordering::SeqCst).rev().cloned());
+    validate_value(x.iter_with_order(Ordering::Relaxed).cloned());
+    validate_value(x.iter_with_order(Ordering::SeqCst).rev().cloned());
     validate_value(x.into_iter());
 }

--- a/tests/iter_mut.rs
+++ b/tests/iter_mut.rs
@@ -10,8 +10,8 @@ fn iter_mut_when_none() {
     }
 
     let mut x = ConcurrentOption::<String>::none();
-    validate(x.iter_mut());
-    validate(x.iter_mut().rev());
+    validate(x.exclusive_iter_mut());
+    validate(x.exclusive_iter_mut().rev());
     validate((&mut x).into_iter());
 }
 
@@ -26,14 +26,14 @@ fn iter_mut_when_some() {
     }
 
     let mut x = ConcurrentOption::some(3.to_string());
-    validate(x.iter_mut());
-    assert_eq!(x.as_ref(Ordering::Relaxed), Some(&7.to_string()));
+    validate(x.exclusive_iter_mut());
+    assert_eq!(x.as_ref_with_order(Ordering::Relaxed), Some(&7.to_string()));
 
     let mut x = ConcurrentOption::some(3.to_string());
-    validate(x.iter_mut().rev());
-    assert_eq!(x.as_ref(Ordering::Relaxed), Some(&7.to_string()));
+    validate(x.exclusive_iter_mut().rev());
+    assert_eq!(x.as_ref_with_order(Ordering::Relaxed), Some(&7.to_string()));
 
     let mut x = ConcurrentOption::some(3.to_string());
     validate((&mut x).into_iter());
-    assert_eq!(x.as_ref(Ordering::Relaxed), Some(&7.to_string()));
+    assert_eq!(x.as_ref_with_order(Ordering::Relaxed), Some(&7.to_string()));
 }

--- a/tests/new.rs
+++ b/tests/new.rs
@@ -7,8 +7,8 @@ fn some() {
     assert_eq!(x, ConcurrentOption::some(3.to_string()));
     assert_ne!(x, ConcurrentOption::none());
 
-    assert!(x.is_some(Ordering::Relaxed));
-    assert!(!x.is_none(Ordering::Relaxed));
+    assert!(x.is_some_with_order(Ordering::Relaxed));
+    assert!(!x.is_none_with_order(Ordering::Relaxed));
 }
 
 #[test]
@@ -16,12 +16,12 @@ fn none() {
     let x = ConcurrentOption::<String>::none();
     assert_ne!(x, ConcurrentOption::some(3.to_string()));
     assert_eq!(x, ConcurrentOption::none());
-    assert!(!x.is_some(Ordering::Relaxed));
-    assert!(x.is_none(Ordering::Relaxed));
+    assert!(!x.is_some_with_order(Ordering::Relaxed));
+    assert!(x.is_none_with_order(Ordering::Relaxed));
 
     let x = ConcurrentOption::default();
     assert_ne!(x, ConcurrentOption::some(3.to_string()));
     assert_eq!(x, ConcurrentOption::none());
-    assert!(!x.is_some(Ordering::Relaxed));
-    assert!(x.is_none(Ordering::Relaxed));
+    assert!(!x.is_some_with_order(Ordering::Relaxed));
+    assert!(x.is_none_with_order(Ordering::Relaxed));
 }

--- a/tests/raw.rs
+++ b/tests/raw.rs
@@ -30,5 +30,5 @@ fn raw_get_mut() {
     let p = x.raw_get_mut(Ordering::Relaxed);
     let p = p.unwrap();
     let _ = unsafe { p.replace(7.to_string()) }; // only write leads to memory leak
-    assert_eq!(x.as_ref(Ordering::Relaxed), Some(&7.to_string()));
+    assert_eq!(x.as_ref_with_order(Ordering::Relaxed), Some(&7.to_string()));
 }


### PR DESCRIPTION
* names of methods requiring an ordering end with `_with_order`
* names of methods requiring an exclusive mutable reference start with `exclusive_`.
* concurrent take method is implemented and tested
* map_ref method is implemented and tested