### PR TITLE
thread-safe api is extended

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-concurrent-option"
-version = "1.2.0"
+version = "1.3.0"
 edition = "2021"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "ConcurrentOption is a lock-free concurrent read and write option type."

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -1,0 +1,70 @@
+use crate::states::*;
+use core::sync::atomic::{AtomicU8, Ordering};
+
+pub(crate) struct Handle<'a> {
+    state: &'a AtomicU8,
+    success_state: StateU8,
+}
+
+impl<'a> Handle<'a> {
+    pub fn get(
+        state: &'a AtomicU8,
+        initial_state: StateU8,
+        success_state: StateU8,
+    ) -> Option<Self> {
+        match state
+            .compare_exchange(
+                initial_state,
+                RESERVED,
+                Ordering::Acquire,
+                Ordering::Relaxed,
+            )
+            .is_ok()
+        {
+            true => Some(Self {
+                state,
+                success_state,
+            }),
+            false => None,
+        }
+    }
+
+    pub fn spin_get(
+        state: &'a AtomicU8,
+        initial_state: StateU8,
+        success_state: StateU8,
+    ) -> Option<Self> {
+        loop {
+            match state.compare_exchange(
+                initial_state,
+                RESERVED,
+                Ordering::Acquire,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => {
+                    return Some(Self {
+                        state,
+                        success_state,
+                    })
+                }
+                Err(previous_state) => match previous_state {
+                    RESERVED => continue,
+                    _ => return None,
+                },
+            }
+        }
+    }
+}
+
+impl<'a> Drop for Handle<'a> {
+    fn drop(&mut self) {
+        self.state
+            .compare_exchange(
+                RESERVED,
+                self.success_state,
+                Ordering::Release,
+                Ordering::Relaxed,
+            )
+            .expect("Failed to update the concurrent state after concurrent state mutation");
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ mod concurrent;
 mod concurrent_option;
 mod drop;
 mod exclusive;
+mod handle;
 mod into;
 mod into_option;
 mod mut_handle;
@@ -27,7 +28,7 @@ mod states;
 mod with_order;
 
 pub use common_traits::iter;
-
 pub use concurrent_option::ConcurrentOption;
 pub use into_option::IntoOption;
-pub use states::State;
+pub use mut_handle::MutHandle;
+pub use states::{State, StateU8, NONE, RESERVED, SOME};

--- a/src/mut_handle.rs
+++ b/src/mut_handle.rs
@@ -1,41 +1,26 @@
-use crate::states::*;
-use core::sync::atomic::{AtomicU8, Ordering};
+use crate::{states::*, ConcurrentOption};
+use core::{
+    cell::UnsafeCell,
+    mem::MaybeUninit,
+    sync::atomic::{AtomicU8, Ordering},
+};
 
-pub(crate) struct MutHandle<'a> {
+/// Provides a mut-handle on the optional.
+pub struct MutHandle<'a, T> {
     state: &'a AtomicU8,
-    success_state: StateInner,
+    success_state: StateU8,
+    /// Provides direct access to the cell holding the data of the optional.
+    pub value: &'a UnsafeCell<MaybeUninit<T>>,
 }
 
-impl<'a> MutHandle<'a> {
-    pub fn get(
-        state: &'a AtomicU8,
-        initial_state: StateInner,
-        success_state: StateInner,
-    ) -> Option<Self> {
-        match state
-            .compare_exchange(
-                initial_state,
-                RESERVED,
-                Ordering::Acquire,
-                Ordering::Relaxed,
-            )
-            .is_ok()
-        {
-            true => Some(Self {
-                state,
-                success_state,
-            }),
-            false => None,
-        }
-    }
-
-    pub fn spin_get(
-        state: &'a AtomicU8,
-        initial_state: StateInner,
-        success_state: StateInner,
+impl<'a, T> MutHandle<'a, T> {
+    pub(crate) fn spin_get(
+        option: &'a ConcurrentOption<T>,
+        initial_state: StateU8,
+        success_state: StateU8,
     ) -> Option<Self> {
         loop {
-            match state.compare_exchange(
+            match option.state.compare_exchange(
                 initial_state,
                 RESERVED,
                 Ordering::Acquire,
@@ -43,9 +28,10 @@ impl<'a> MutHandle<'a> {
             ) {
                 Ok(_) => {
                     return Some(Self {
-                        state,
+                        state: &option.state,
                         success_state,
-                    })
+                        value: &option.value,
+                    });
                 }
                 Err(previous_state) => match previous_state {
                     RESERVED => continue,
@@ -54,9 +40,21 @@ impl<'a> MutHandle<'a> {
             }
         }
     }
+
+    /// Creates a `&mut T` reference to the underlying value of the optional.
+    ///
+    /// # Safety
+    ///
+    /// This operation might lead to undefined behavior:
+    /// * if we use it while other threads are accessing the data, or
+    /// * if the optional `is_none` when we access the value.
+    pub unsafe fn get_mut(&self) -> &mut T {
+        let x = unsafe { &mut *self.value.get() };
+        unsafe { MaybeUninit::assume_init_mut(x) }
+    }
 }
 
-impl<'a> Drop for MutHandle<'a> {
+impl<'a, T> Drop for MutHandle<'a, T> {
     fn drop(&mut self) {
         self.state
             .compare_exchange(

--- a/src/states.rs
+++ b/src/states.rs
@@ -1,13 +1,17 @@
 use core::sync::atomic::Ordering;
 
-pub type StateInner = u8;
+/// State represented as u8.
+pub type StateU8 = u8;
 
 pub const ORDER_LOAD: Ordering = Ordering::Acquire;
 pub const ORDER_STORE: Ordering = Ordering::SeqCst;
 
-pub const NONE: StateInner = 0;
-pub const RESERVED: StateInner = 1;
-pub const SOME: StateInner = 2;
+/// State where the optional does not have a value.
+pub const NONE: StateU8 = 0;
+/// State where the optional's value is being transitioned.
+pub const RESERVED: StateU8 = 1;
+/// State where the optional contains a value.
+pub const SOME: StateU8 = 2;
 
 /// Concurrent state of the optional.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -22,7 +26,7 @@ pub enum State {
 
 impl State {
     #[allow(clippy::panic, clippy::missing_panics_doc)]
-    pub(crate) fn new(state: StateInner) -> Self {
+    pub(crate) fn new(state: StateU8) -> Self {
         match state {
             NONE => Self::None,
             SOME => Self::Some,

--- a/tests/concurrent_clone_into_option.rs
+++ b/tests/concurrent_clone_into_option.rs
@@ -1,0 +1,75 @@
+use orx_concurrent_option::*;
+use std::time::Duration;
+use test_case::test_matrix;
+
+#[test_matrix(
+    [2, 4, 8, 16],
+    [false, true]
+)]
+fn concurrent_clone_into_option_single_writer(num_readers: usize, do_sleep: bool) {
+    let maybe = ConcurrentOption::some(7.to_string());
+    let maybe_ref = &maybe;
+
+    std::thread::scope(|s| {
+        for _ in 0..(num_readers / 2) {
+            s.spawn(move || reader(do_sleep, maybe_ref));
+        }
+
+        s.spawn(move || cloner(do_sleep, maybe_ref));
+
+        for _ in 0..(num_readers / 2) {
+            s.spawn(move || reader(do_sleep, maybe_ref));
+        }
+    });
+}
+
+#[test_matrix(
+    [4, 8],
+    [2, 4, 8, 16],
+    [false, true]
+)]
+fn concurrent_clone_into_option_multiple_writer(
+    num_writers: usize,
+    num_readers: usize,
+    do_sleep: bool,
+) {
+    let maybe = ConcurrentOption::some(7.to_string());
+    let maybe_ref = &maybe;
+
+    std::thread::scope(|s| {
+        for _ in 0..(num_writers / 2) {
+            s.spawn(move || cloner(do_sleep, maybe_ref));
+        }
+
+        for _ in 0..num_readers {
+            s.spawn(move || reader(do_sleep, maybe_ref));
+        }
+
+        for _ in 0..(num_writers / 2) {
+            s.spawn(move || cloner(do_sleep, maybe_ref));
+        }
+    });
+}
+
+// helpers
+fn reader(do_sleep: bool, maybe: &ConcurrentOption<String>) {
+    for _ in 0..100 {
+        sleep(do_sleep);
+        let is_none_or_seven = maybe.map(|x| x == &7.to_string()).unwrap_or(true);
+        assert!(is_none_or_seven);
+    }
+}
+
+fn cloner(do_sleep: bool, maybe: &ConcurrentOption<String>) {
+    for _ in 0..100 {
+        sleep(do_sleep);
+        let _ = maybe.clone_into_option();
+    }
+}
+
+fn sleep(do_sleep: bool) {
+    if do_sleep {
+        let duration = Duration::from_millis(24);
+        std::thread::sleep(duration);
+    }
+}


### PR DESCRIPTION
* `set_some` method is implemented.
* `clone_into_option` method is impelemented.
* Unsafe `get_mut` methods is implemented.
* Safety issues on `get_or_insert` and `is_some_and` and `map` methods are fixed.